### PR TITLE
Update ENV variable for TRAVIS

### DIFF
--- a/src/Blt/Plugin/EnvironmentDetector/TravisDetector.php
+++ b/src/Blt/Plugin/EnvironmentDetector/TravisDetector.php
@@ -9,7 +9,7 @@ class TravisDetector extends EnvironmentDetector {
     return isset($_ENV['TRAVIS']) ? 'travis' : null;
   }
 
-  public static function getCiSettingsFile() {
+  public static function getCiSettingsFile() : string {
     if (self::getCiEnv() === 'travis') {
       return sprintf('%s/vendor/acquia/blt-travis/settings/travis.settings.php', dirname(DRUPAL_ROOT));
     }

--- a/src/Blt/Plugin/EnvironmentDetector/TravisDetector.php
+++ b/src/Blt/Plugin/EnvironmentDetector/TravisDetector.php
@@ -6,10 +6,10 @@ use Acquia\Blt\Robo\Common\EnvironmentDetector;
 
 class TravisDetector extends EnvironmentDetector {
   public static function getCiEnv() {
-    return isset($_ENV['TRAVIS']) ? 'travis' : null;
+    return getenv('TRAVIS') ? 'travis' : null;
   }
 
-  public static function getCiSettingsFile() : string {
+  public static function getCiSettingsFile(): string {
     if (self::getCiEnv() === 'travis') {
       return sprintf('%s/vendor/acquia/blt-travis/settings/travis.settings.php', dirname(DRUPAL_ROOT));
     }


### PR DESCRIPTION
**Motivation**
With the changes in PR #5 the following error has been detected within a Travis build.

**Proposed changes**
The current format for retrieving the TRAVIS environment variable doesn't function as expected. Update to use `getenv` function.

**Testing steps**
- [ ] Update `acquia/blt`: v`13.5.2`. 
- [ ] Verify the travis build loads the global `TRAVIS` environment variable and you don't encounter the error below:
```
TypeError: Return value of Acquia\BltTravis\Blt\Plugin\EnvironmentDetector\TravisDetector::getCiSettingsFile() must be of the type string, none returned in /home/travis/build/.../vendor/acquia/blt-travis/src/Blt/Plugin/EnvironmentDetector/TravisDetector.php on line 16 #0 [internal function]: Acquia\BltTravis\Blt\Plugin\EnvironmentDetector\TravisDetector::getCiSettingsFile()
```

**Merge requirements**
- [ ] _Bug_, _enhancement_, or _breaking change_ label applied
- [ ] Manual testing by a reviewer
