### PR TITLE
BLT 13.5.1 Support.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
     "sort-packages": true
   },
   "require": {},
+  "conflict": {
+    "acquia/blt": "<13.5.1"
+  },
   "autoload": {
     "psr-4": {
       "Acquia\\BltTravis\\": "./src/"

--- a/src/Blt/Plugin/EnvironmentDetector/TravisDetector.php
+++ b/src/Blt/Plugin/EnvironmentDetector/TravisDetector.php
@@ -9,7 +9,7 @@ class TravisDetector extends EnvironmentDetector {
     return isset($_ENV['TRAVIS']) ? 'travis' : null;
   }
 
-  public static function getCiSettingsFile() {
+  public static function getCiSettingsFile(): string {
     if (self::getCiEnv() === 'travis') {
       return sprintf('%s/vendor/acquia/blt-travis/settings/travis.settings.php', dirname(DRUPAL_ROOT));
     }


### PR DESCRIPTION
**Motivation**
N/A. Makes the getCiSettingsFile method compatible with BLT 13.5.1.