### PR TITLE
Adding acquia-pipelines settings as fallback to fix issues when runni…

### DIFF
--- a/src/Blt/Plugin/EnvironmentDetector/TravisDetector.php
+++ b/src/Blt/Plugin/EnvironmentDetector/TravisDetector.php
@@ -12,6 +12,8 @@ class TravisDetector extends EnvironmentDetector {
   public static function getCiSettingsFile(): string {
     if (self::getCiEnv() === 'travis') {
       return sprintf('%s/vendor/acquia/blt-travis/settings/travis.settings.php', dirname(DRUPAL_ROOT));
+    }else{
+      return sprintf('%s/vendor/acquia/blt/settings/pipelines.settings.php', dirname(DRUPAL_ROOT));
     }
   }
 }


### PR DESCRIPTION
**Motivation**
Fixes #3 

What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. 
Since I run `aquia-pipelines` for deployment and `travis-ci` for end to end testing. Some of the configurations get missed during the building process. This might be a very particular case but the fallback does not affect the regular `travis-ci` process and it connects better with aquia in general.

**Proposed changes**
What does this PR change? How does this impact end users? Are manual or automatic updates required?
Add a `aquia-pipelines` fallback option so if user in case user needs both systems.

**Testing steps**
How can we replicate the issue and verify that this PR fixes it?

**Merge requirements**
- [ ] _Bug_, _enhancement_, or _breaking change_ label applied
- [x] Manual testing by a reviewer
